### PR TITLE
Fix: Correct syntax error in App.js

### DIFF
--- a/bmi/src/App.js
+++ b/bmi/src/App.js
@@ -353,7 +353,3 @@ function App() {
 }
 
 export default App;
-
-}
-
-export default App;


### PR DESCRIPTION
Removes an extraneous closing curly brace and a duplicate export statement at the end of bmi/src/App.js that was causing an ESLint syntax error during the Vercel build.

This commit assumes the user has manually applied this fix as the automated tools were unable to reliably perform the edit.